### PR TITLE
Update to alpine 3.8 (3.8.1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.7
+FROM alpine:3.8
+# Image used will affectively be 3.8.1 with the security hotfix.
 
 LABEL maintainer devops@travelaudience.com
 


### PR DESCRIPTION
Update to alpine 3.8.1 affectively. A new tag doesn't exist but technically newly downloaded version are already 3.8.1 .